### PR TITLE
chore: update version to 15.3.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<artifactId>fess-ds-json</artifactId>
 	<packaging>jar</packaging>
 	<name>JSON Data Store</name>
-	<version>15.2.1-SNAPSHOT</version>
+	<version>15.3.0-SNAPSHOT</version>
 	<scm>
 		<connection>scm:git:git@github.com:codelibs/fess-ds-json.git</connection>
 		<developerConnection>scm:git:git@github.com:codelibs/fess-ds-json.git</developerConnection>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.2.0</version>
+		<version>15.3.0</version>
 		<relativePath />
 	</parent>
 	<build>


### PR DESCRIPTION
## Summary
This PR updates the project version to 15.3.0-SNAPSHOT for the next development cycle. I've updated both the artifact version and the parent POM version to maintain consistency across the Fess ecosystem.

## Changes Made
- Updated artifact version from `15.2.1-SNAPSHOT` to `15.3.0-SNAPSHOT` in `pom.xml:7`
- Updated parent POM version from `15.2.0` to `15.3.0` in `pom.xml:17`

## Rationale
Following the recent 15.2.0 release, this update prepares the repository for the next development iteration. The version bump to 15.3.0-SNAPSHOT aligns with the Fess parent project's version scheme and ensures proper dependency management for ongoing development work.

## Testing
- Build verification: `mvn clean package`
- No functional changes introduced, version metadata update only

## Additional Notes
This is a standard maintenance update that should be merged before any new feature development for the 15.3.x series begins.